### PR TITLE
Implement Sudoku Compose app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.sudokuapp">
+
+    <application
+        android:allowBackup="true"
+        android:label="SudokuApp"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.MaterialComponents.DayNight.DarkActionBar">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/example/sudokuapp/MainActivity.kt
+++ b/app/src/main/java/com/example/sudokuapp/MainActivity.kt
@@ -1,0 +1,21 @@
+package com.example.sudokuapp
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import com.example.sudokuapp.ui.SudokuScreen
+import com.example.sudokuapp.viewmodel.SudokuViewModel
+
+/** Main Activity hosting the Sudoku game screen. */
+class MainActivity : ComponentActivity() {
+
+    private val viewModel: SudokuViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            SudokuScreen(viewModel)
+        }
+    }
+}

--- a/app/src/main/java/com/example/sudokuapp/data/SudokuRepository.kt
+++ b/app/src/main/java/com/example/sudokuapp/data/SudokuRepository.kt
@@ -1,0 +1,37 @@
+package com.example.sudokuapp.data
+
+import android.content.SharedPreferences
+import com.example.sudokuapp.model.Difficulty
+import com.example.sudokuapp.util.SudokuUtils
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/** Repository responsible for generating puzzles and storing history. */
+class SudokuRepository(private val prefs: SharedPreferences) {
+
+    suspend fun generateNewPuzzle(difficulty: Difficulty): Array<IntArray> = withContext(Dispatchers.Default) {
+        SudokuUtils.generatePuzzle(difficulty.removed)
+    }
+
+    suspend fun solvePuzzle(board: Array<IntArray>): Array<IntArray> = withContext(Dispatchers.Default) {
+        val copy = Array(board.size) { board[it].clone() }
+        SudokuUtils.solveBoard(copy)
+        copy
+    }
+
+    fun saveClearTime(timeMillis: Long) {
+        val history = prefs.getStringSet(KEY_HISTORY, mutableSetOf())?.toMutableSet() ?: mutableSetOf()
+        history.add(timeMillis.toString())
+        prefs.edit().putStringSet(KEY_HISTORY, history).apply()
+    }
+
+    fun getClearHistory(): List<Long> {
+        return prefs.getStringSet(KEY_HISTORY, mutableSetOf())
+            ?.mapNotNull { it.toLongOrNull() }
+            ?.sortedDescending() ?: emptyList()
+    }
+
+    companion object {
+        private const val KEY_HISTORY = "history"
+    }
+}

--- a/app/src/main/java/com/example/sudokuapp/model/Models.kt
+++ b/app/src/main/java/com/example/sudokuapp/model/Models.kt
@@ -1,0 +1,17 @@
+package com.example.sudokuapp.model
+
+/** Represents a single cell on the Sudoku board. */
+data class SudokuCell(
+    val row: Int,
+    val col: Int,
+    var value: Int = 0,
+    var isFixed: Boolean = false,
+    var isValid: Boolean = true
+)
+
+/** Difficulty enumeration controlling the number of removed cells. */
+enum class Difficulty(val removed: Int) {
+    EASY(30),
+    MEDIUM(40),
+    HARD(50)
+}

--- a/app/src/main/java/com/example/sudokuapp/ui/SudokuScreen.kt
+++ b/app/src/main/java/com/example/sudokuapp/ui/SudokuScreen.kt
@@ -1,0 +1,100 @@
+package com.example.sudokuapp.ui
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.sudokuapp.model.Difficulty
+import com.example.sudokuapp.viewmodel.SudokuViewModel
+
+/** Composable displaying the entire Sudoku game UI. */
+@Composable
+fun SudokuScreen(viewModel: SudokuViewModel) {
+    val board by viewModel.boardState.collectAsState()
+    var selectedCell by remember { mutableStateOf<Pair<Int, Int>?>(null) }
+
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+        DifficultySelector { viewModel.newGame(it) }
+        Spacer(Modifier.height(16.dp))
+        Board(board, selectedCell) { r, c -> selectedCell = Pair(r, c) }
+        Spacer(Modifier.height(16.dp))
+        NumberPad { number ->
+            selectedCell?.let { (r, c) -> viewModel.setCellValue(r, c, number) }
+        }
+        Spacer(Modifier.height(16.dp))
+        Row {
+            Button(onClick = { viewModel.solveGame() }) { Text("Solve") }
+        }
+        Spacer(Modifier.height(16.dp))
+        HistoryList(viewModel.history)
+    }
+}
+
+@Composable
+fun DifficultySelector(onSelect: (Difficulty) -> Unit) {
+    Row(horizontalArrangement = Arrangement.SpaceEvenly) {
+        Difficulty.values().forEach { diff ->
+            Button(onClick = { onSelect(diff) }, modifier = Modifier.padding(4.dp)) {
+                Text(diff.name)
+            }
+        }
+    }
+}
+
+@Composable
+fun Board(board: Array<IntArray>, selected: Pair<Int, Int>?, onCellSelected: (Int, Int) -> Unit) {
+    Column {
+        board.forEachIndexed { rowIdx, row ->
+            Row {
+                row.forEachIndexed { colIdx, value ->
+                    val isSelected = selected?.first == rowIdx && selected.second == colIdx
+                    Box(
+                        modifier = Modifier
+                            .size(36.dp)
+                            .border(BorderStroke(1.dp, Color.Black))
+                            .background(if (isSelected) Color.LightGray else Color.White)
+                            .clickable { onCellSelected(rowIdx, colIdx) },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        if (value != 0) Text(value.toString(), fontSize = 18.sp)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun NumberPad(onNumberSelected: (Int) -> Unit) {
+    Column {
+        for (i in 1..9 step 3) {
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
+                for (j in i until i + 3) {
+                    OutlinedButton(
+                        modifier = Modifier.padding(4.dp).size(48.dp),
+                        onClick = { onNumberSelected(j) }
+                    ) { Text(j.toString()) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun HistoryList(times: List<Long>) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text("History", style = MaterialTheme.typography.titleMedium)
+        times.forEach { time ->
+            Text("${time}ms")
+        }
+    }
+}

--- a/app/src/main/java/com/example/sudokuapp/util/SudokuUtils.kt
+++ b/app/src/main/java/com/example/sudokuapp/util/SudokuUtils.kt
@@ -1,0 +1,100 @@
+package com.example.sudokuapp.util
+
+import kotlin.random.Random
+
+/** Utility class containing functions to generate and solve Sudoku puzzles using backtracking. */
+object SudokuUtils {
+    private const val BOARD_SIZE = 9
+
+    /** Generate a solvable Sudoku puzzle with given number of cells removed based on difficulty. */
+    fun generatePuzzle(removedCells: Int): Array<IntArray> {
+        val board = Array(BOARD_SIZE) { IntArray(BOARD_SIZE) }
+        fillDiagonalSubgrids(board)
+        solveBoard(board)
+        removeCells(board, removedCells)
+        return board
+    }
+
+    /** Fill the diagonal 3x3 blocks, which are independent of each other. */
+    private fun fillDiagonalSubgrids(board: Array<IntArray>) {
+        for (i in 0 until BOARD_SIZE step 3) {
+            fillSubgrid(board, i, i)
+        }
+    }
+
+    private fun fillSubgrid(board: Array<IntArray>, row: Int, col: Int) {
+        var num: Int
+        for (i in 0 until 3) {
+            for (j in 0 until 3) {
+                do {
+                    num = Random.nextInt(1, 10)
+                } while (!isSafe(board, row + i, col + j, num))
+                board[row + i][col + j] = num
+            }
+        }
+    }
+
+    /** Backtracking solver. Returns true if solved. */
+    fun solveBoard(board: Array<IntArray>): Boolean {
+        for (row in 0 until BOARD_SIZE) {
+            for (col in 0 until BOARD_SIZE) {
+                if (board[row][col] == 0) {
+                    for (num in 1..9) {
+                        if (isSafe(board, row, col, num)) {
+                            board[row][col] = num
+                            if (solveBoard(board)) {
+                                return true
+                            }
+                            board[row][col] = 0
+                        }
+                    }
+                    return false
+                }
+            }
+        }
+        return true
+    }
+
+    private fun isSafe(board: Array<IntArray>, row: Int, col: Int, num: Int): Boolean {
+        return isRowSafe(board, row, num) &&
+            isColSafe(board, col, num) &&
+            isSubgridSafe(board, row - row % 3, col - col % 3, num)
+    }
+
+    private fun isRowSafe(board: Array<IntArray>, row: Int, num: Int): Boolean {
+        for (col in 0 until BOARD_SIZE) {
+            if (board[row][col] == num) return false
+        }
+        return true
+    }
+
+    private fun isColSafe(board: Array<IntArray>, col: Int, num: Int): Boolean {
+        for (row in 0 until BOARD_SIZE) {
+            if (board[row][col] == num) return false
+        }
+        return true
+    }
+
+    private fun isSubgridSafe(board: Array<IntArray>, startRow: Int, startCol: Int, num: Int): Boolean {
+        for (r in 0 until 3) {
+            for (c in 0 until 3) {
+                if (board[startRow + r][startCol + c] == num) return false
+            }
+        }
+        return true
+    }
+
+    /** Randomly remove cells to create a puzzle. */
+    private fun removeCells(board: Array<IntArray>, removedCells: Int) {
+        var count = removedCells
+        while (count > 0) {
+            val cellId = Random.nextInt(0, BOARD_SIZE * BOARD_SIZE)
+            val row = cellId / BOARD_SIZE
+            val col = cellId % BOARD_SIZE
+            if (board[row][col] != 0) {
+                board[row][col] = 0
+                count--
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/sudokuapp/viewmodel/SudokuViewModel.kt
+++ b/app/src/main/java/com/example/sudokuapp/viewmodel/SudokuViewModel.kt
@@ -1,0 +1,46 @@
+package com.example.sudokuapp.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.sudokuapp.data.SudokuRepository
+import com.example.sudokuapp.model.Difficulty
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/** Holds UI state and exposes operations for the Sudoku screen. */
+class SudokuViewModel(app: Application) : AndroidViewModel(app) {
+
+    private val repository = SudokuRepository(
+        app.getSharedPreferences("sudoku_prefs", Application.MODE_PRIVATE)
+    )
+
+    private val _boardState = MutableStateFlow(Array(9) { IntArray(9) })
+    val boardState: StateFlow<Array<IntArray>> = _boardState
+
+    val history: List<Long>
+        get() = repository.getClearHistory()
+
+    fun newGame(difficulty: Difficulty) {
+        viewModelScope.launch {
+            _boardState.value = repository.generateNewPuzzle(difficulty)
+        }
+    }
+
+    fun solveGame() {
+        viewModelScope.launch {
+            _boardState.value = repository.solvePuzzle(_boardState.value)
+        }
+    }
+
+    fun setCellValue(row: Int, col: Int, value: Int) {
+        val board = _boardState.value.map { it.clone() }.toTypedArray()
+        board[row][col] = value
+        _boardState.value = board
+    }
+
+    fun saveClearTime(timeMillis: Long) {
+        repository.saveClearTime(timeMillis)
+    }
+}


### PR DESCRIPTION
## Summary
- add Android manifest
- implement Sudoku utils with backtracking
- add models for cells and difficulty
- create repository for puzzle generation & history
- implement ViewModel with coroutine support
- compose UI with board, keypad and history
- main activity hosts Sudoku screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848d6752b58832989a8be99eefa43eb