### PR TITLE
Add Electron-Python Instagram automation skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Insta Automation App
+
+Desktop Instagram automation using Electron and Python. The backend exposes a FastAPI service which the Electron UI communicates with via secure IPC.
+
+## Development
+
+```bash
+npm install
+npm start
+```
+
+On first run, the app downloads an embedded Python distribution and installs the requirements listed in `python/requirements.txt`.
+The FastAPI server runs on `http://localhost:3030`.

--- a/main.js
+++ b/main.js
@@ -1,0 +1,65 @@
+const { app, BrowserWindow, ipcMain } = require('electron');
+const { autoUpdater } = require('electron-updater');
+const path = require('path');
+const { spawn } = require('child_process');
+
+let pythonProcess = null;
+
+function setupPython() {
+  require('./scripts/setupPython');
+}
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      preload: path.join(__dirname, 'resources', 'app', 'js', 'preload.js')
+    }
+  });
+  win.loadFile(path.join('resources', 'app', 'templates', 'login.html'));
+}
+
+function startPython() {
+  const script = path.join(__dirname, 'python', 'main.py');
+  const py = path.join(__dirname, 'resources', 'app', 'script', 'python-3.11.0-embed-amd64', 'python.exe');
+  const cmd = process.platform === 'win32' ? py : 'python3';
+  const args = [script];
+  pythonProcess = spawn(cmd, args);
+  pythonProcess.stdout.on('data', (data) => console.log(`PYTHON: ${data}`));
+  pythonProcess.stderr.on('data', (data) => console.error(`PYTHON ERR: ${data}`));
+}
+
+app.whenReady().then(() => {
+  setupPython();
+  startPython();
+  createWindow();
+  autoUpdater.checkForUpdatesAndNotify();
+});
+
+app.on('before-quit', () => {
+  if (pythonProcess) pythonProcess.kill();
+});
+
+ipcMain.handle('get-device-info', () => ({ platform: process.platform }));
+ipcMain.handle('run-login', async (_e, data) => {
+  return fetch('http://127.0.0.1:3030/run-login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  }).then(res => res.json());
+});
+ipcMain.handle('run-bot', async (_e, data) => {
+  return fetch('http://127.0.0.1:3030/run-bot', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  }).then(res => res.json());
+});
+ipcMain.handle('run-post', async (_e, data) => {
+  return fetch('http://127.0.0.1:3030/run-post', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  }).then(res => res.json());
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "insta-automation-app",
+  "version": "1.0.0",
+  "description": "Instagram automation desktop app",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "pack": "electron-builder --dir",
+    "dist": "electron-builder"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "electron-updater": "^5.3.0",
+    "extract-zip": "^2.0.1"
+  },
+  "devDependencies": {
+    "electron": "^25.3.0",
+    "electron-builder": "^23.6.0"
+  },
+  "build": {
+    "appId": "com.example.instaautomation",
+    "files": ["**/*"],
+    "extraResources": [
+      {
+        "from": "python/",
+        "to": "python",
+        "filter": ["**/*"]
+      }
+    ],
+    "publish": [
+      {
+        "provider": "github"
+      }
+    ]
+  }
+}

--- a/python/bot.py
+++ b/python/bot.py
@@ -1,0 +1,13 @@
+import argparse
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Run Instagram bot actions')
+    parser.add_argument('--follow', nargs='*')
+    parser.add_argument('--like', nargs='*')
+    args = parser.parse_args()
+    # Placeholder logic
+    print('Bot actions:', args)
+
+if __name__ == '__main__':
+    main()

--- a/python/login.py
+++ b/python/login.py
@@ -1,0 +1,18 @@
+from instagrapi import Client
+import argparse
+import json
+from pathlib import Path
+
+def main(username: str, password: str):
+    cl = Client()
+    cl.login(username, password)
+    session = cl.get_settings()
+    with open(Path(__file__).resolve().parent / 'session.json', 'w') as f:
+        json.dump(session, f)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Login to Instagram')
+    parser.add_argument('username')
+    parser.add_argument('password')
+    args = parser.parse_args()
+    main(args.username, args.password)

--- a/python/main.py
+++ b/python/main.py
@@ -1,0 +1,55 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse, RedirectResponse
+from pydantic import BaseModel
+from pathlib import Path
+import subprocess
+import httpx
+from jinja2 import Environment, FileSystemLoader
+
+app = FastAPI()
+BASE_DIR = Path(__file__).resolve().parent
+env = Environment(loader=FileSystemLoader(BASE_DIR / 'templates'))
+
+class Creds(BaseModel):
+    username: str
+    password: str
+
+class PostData(BaseModel):
+    path: str
+    caption: str
+
+@app.post('/auth')
+async def auth(data: Creds):
+    # Example BAN check via external API
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post('https://example.com/ban-check', json={'u': data.username})
+            if resp.json().get('status') == 'BAN':
+                raise HTTPException(status_code=403, detail='Banned')
+    except Exception:
+        pass
+    return JSONResponse({'status': 'ok'})
+
+@app.post('/run-login')
+async def run_login(data: Creds):
+    subprocess.run(['python', str(BASE_DIR / 'login.py'), data.username, data.password])
+    return JSONResponse({'status': 'login-started'})
+
+@app.post('/run-bot')
+async def run_bot(payload: dict):
+    subprocess.run(['python', str(BASE_DIR / 'bot.py')])
+    return JSONResponse({'status': 'bot-started'})
+
+@app.post('/run-post')
+async def run_post(data: PostData):
+    subprocess.run(['python', str(BASE_DIR / 'post.py'), data.path, data.caption])
+    return RedirectResponse('/done')
+
+@app.get('/done')
+async def done():
+    template = env.get_template('done.json')
+    return JSONResponse(template.render())
+
+if __name__ == '__main__':
+    import uvicorn
+    uvicorn.run(app, host='127.0.0.1', port=3030)

--- a/python/post.py
+++ b/python/post.py
@@ -1,0 +1,14 @@
+import argparse
+from pathlib import Path
+
+
+def main(path: str, caption: str):
+    print('Post', path, caption)
+    # Placeholder for pillow/moviepy processing and instagrapi upload
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Upload a post')
+    parser.add_argument('path')
+    parser.add_argument('caption')
+    args = parser.parse_args()
+    main(args.path, args.caption)

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,9 @@
+fastapi
+uvicorn
+instagrapi
+pillow
+moviepy
+pyotp
+cryptography
+httpx
+jinja2

--- a/python/templates/done.json
+++ b/python/templates/done.json
@@ -1,0 +1,1 @@
+{"status": "completed"}

--- a/resources/app/js/preload.js
+++ b/resources/app/js/preload.js
@@ -1,0 +1,8 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('api', {
+  getDeviceInfo: () => ipcRenderer.invoke('get-device-info'),
+  runLogin: (credentials) => ipcRenderer.invoke('run-login', credentials),
+  runBot: (options) => ipcRenderer.invoke('run-bot', options),
+  runPost: (data) => ipcRenderer.invoke('run-post', data)
+});

--- a/resources/app/templates/dashboard.html
+++ b/resources/app/templates/dashboard.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Dashboard</title>
+</head>
+<body>
+  <div id="sidebar">
+    <a href="dashboard.html">Dashboard</a> |
+    <a href="scheduler.html">Scheduler</a>
+  </div>
+  <h2>Dashboard</h2>
+  <p>Coming Soon...</p>
+</body>
+</html>

--- a/resources/app/templates/login.html
+++ b/resources/app/templates/login.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Login</title>
+</head>
+<body>
+  <h1>Login</h1>
+  <form id="loginForm">
+    <input type="text" id="username" placeholder="Username" required />
+    <input type="password" id="password" placeholder="Password" required />
+    <button type="submit">Login</button>
+  </form>
+  <div id="error" style="color:red;"></div>
+  <script>
+  document.getElementById('loginForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const username = document.getElementById('username').value;
+    const password = document.getElementById('password').value;
+    const res = await fetch('http://localhost:3030/auth', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+    if(res.ok){
+      window.location.href = 'dashboard.html';
+    } else {
+      document.getElementById('error').innerText = 'Login failed';
+    }
+  });
+  </script>
+</body>
+</html>

--- a/resources/app/templates/scheduler.html
+++ b/resources/app/templates/scheduler.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Scheduler</title>
+</head>
+<body>
+  <div id="sidebar">
+    <a href="dashboard.html">Dashboard</a> |
+    <a href="scheduler.html">Scheduler</a>
+  </div>
+  <h2>Scheduler</h2>
+  <p>Coming Soon...</p>
+</body>
+</html>

--- a/scripts/setupPython.js
+++ b/scripts/setupPython.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const { spawnSync } = require('child_process');
+const extract = require('extract-zip');
+
+const PY_VERSION = '3.11.0';
+const ZIP_NAME = `python-${PY_VERSION}-embed-amd64.zip`;
+const DOWNLOAD_URL = `https://www.python.org/ftp/python/${PY_VERSION}/${ZIP_NAME}`;
+const baseDir = path.join(__dirname, '..', 'resources', 'app', 'script');
+const pyDir = path.join(baseDir, `python-${PY_VERSION}-embed-amd64`);
+const zipPath = path.join(baseDir, ZIP_NAME);
+
+async function downloadPython() {
+  if (fs.existsSync(pyDir)) return;
+  fs.mkdirSync(baseDir, { recursive: true });
+  if (!fs.existsSync(zipPath)) {
+    console.log('Downloading Python...');
+    await new Promise((resolve, reject) => {
+      const file = fs.createWriteStream(zipPath);
+      https.get(DOWNLOAD_URL, (res) => {
+        res.pipe(file);
+        file.on('finish', () => file.close(resolve));
+      }).on('error', reject);
+    });
+  }
+  console.log('Extracting Python...');
+  await extract(zipPath, { dir: pyDir });
+}
+
+function installPip() {
+  const python = path.join(pyDir, 'python.exe');
+  const req = path.join(__dirname, '..', 'python', 'requirements.txt');
+  const pipFile = path.join(baseDir, '.pip_installed.json');
+  if (fs.existsSync(pipFile)) return;
+  console.log('Installing Python packages...');
+  spawnSync(python, ['-m', 'pip', 'install', '-r', req], { stdio: 'inherit' });
+  const result = spawnSync(python, ['-m', 'pip', 'freeze']);
+  fs.writeFileSync(pipFile, result.stdout);
+}
+
+(async () => {
+  try {
+    await downloadPython();
+    installPip();
+  } catch (err) {
+    console.error('Python setup failed:', err);
+  }
+})();

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Insta Automation</title>
+</head>
+<body>
+  <h1>Instagram Automation</h1>
+  <form id="loginForm">
+    <input type="text" id="username" placeholder="Username" />
+    <input type="password" id="password" placeholder="Password" />
+    <button type="submit">Login</button>
+  </form>
+  <script src="renderer.js"></script>
+</body>
+</html>

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,0 +1,5 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('api', {
+  send: (channel, data) => ipcRenderer.send(channel, data)
+});

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,0 +1,10 @@
+document.getElementById('loginForm').addEventListener('submit', (e) => {
+  e.preventDefault();
+  const username = document.getElementById('username').value;
+  const password = document.getElementById('password').value;
+  fetch('http://127.0.0.1:3030/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  }).then(r => r.json()).then(res => console.log(res));
+});


### PR DESCRIPTION
## Summary
- add preload script with safe IPC methods
- generate HTML templates for login, scheduler, dashboard
- add Python setup script and FastAPI server with bot endpoints
- create CLI scripts for login, bot, and posting
- clean up README and dependencies

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ac912adec83298ce9db4d791f1940